### PR TITLE
PixelController class is now able to construct all output devices depending on the current configuration

### DIFF
--- a/src/main/java/com/neophob/sematrix/output/ArduinoOutput.java
+++ b/src/main/java/com/neophob/sematrix/output/ArduinoOutput.java
@@ -1,0 +1,17 @@
+package com.neophob.sematrix.output;
+
+public abstract class ArduinoOutput extends Output {
+	protected boolean initialized;
+	protected long needUpdate;
+	protected long noUpdate;
+	
+	public ArduinoOutput(PixelControllerOutput controller, String name) {
+		super(controller, name);
+	}
+	
+	public abstract int getArduinoErrorCounter();
+
+	public abstract int getArduinoBufferSize();
+	
+	public abstract long getLatestHeartbeat();
+}

--- a/src/main/java/com/neophob/sematrix/output/Lpd6803Device.java
+++ b/src/main/java/com/neophob/sematrix/output/Lpd6803Device.java
@@ -35,7 +35,7 @@ import com.neophob.sematrix.properties.DeviceConfig;
  * @author michu
  *
  */
-public class Lpd6803Device extends Output {
+public class Lpd6803Device extends ArduinoOutput {
 
 	private static Logger log = Logger.getLogger(Lpd6803Device.class.getName());
 		
@@ -45,9 +45,6 @@ public class Lpd6803Device extends Output {
 	private List<ColorFormat> colorFormat;
 	
 	private Lpd6803 lpd6803 = null;
-	private boolean initialized;
-	
-	private long needUpdate, noUpdate;
 
 	/**
 	 * init the lpd6803 devices
@@ -71,10 +68,6 @@ public class Lpd6803Device extends Output {
 		}
 	}
 	
-	/**
-	 * 
-	 * @return
-	 */
 	public long getLatestHeartbeat() {
 		if (initialized) {
 			return lpd6803.getArduinoHeartbeat();			
@@ -82,10 +75,6 @@ public class Lpd6803Device extends Output {
 		return -1;
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
 	public int getArduinoBufferSize() {
 		if (initialized) {
 			return lpd6803.getArduinoBufferSize();			
@@ -93,10 +82,6 @@ public class Lpd6803Device extends Output {
 		return -1;
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
 	public int getArduinoErrorCounter() {
 		if (initialized) {
 			return lpd6803.getArduinoErrorCounter();			

--- a/src/main/java/com/neophob/sematrix/output/OutputDeviceEnum.java
+++ b/src/main/java/com/neophob/sematrix/output/OutputDeviceEnum.java
@@ -1,0 +1,7 @@
+package com.neophob.sematrix.output;
+
+public enum OutputDeviceEnum {
+	LPD6803,
+	RAINBOWDUINO,
+	ARTNET;
+}

--- a/src/main/java/com/neophob/sematrix/output/RainbowduinoDevice.java
+++ b/src/main/java/com/neophob/sematrix/output/RainbowduinoDevice.java
@@ -33,15 +33,12 @@ import com.neophob.sematrix.glue.Collector;
  * @author michu
  *
  */
-public class RainbowduinoDevice extends Output {
+public class RainbowduinoDevice extends ArduinoOutput {
 
 	private static Logger log = Logger.getLogger(RainbowduinoDevice.class.getName());
 	
 	private List<Integer> allI2cAddress;
 	private Rainbowduino rainbowduino = null;
-	private boolean initialized;
-	
-	long needUpdate, noUpdate;
 
 	/**
 	 * init the rainbowduino devices 
@@ -61,7 +58,6 @@ public class RainbowduinoDevice extends Output {
 		}
 		
 	}
-	
 
 	public long getLatestHeartbeat() {
 		if (initialized) {

--- a/src/main/java/com/neophob/sematrix/properties/PropertiesHelper.java
+++ b/src/main/java/com/neophob/sematrix/properties/PropertiesHelper.java
@@ -34,6 +34,7 @@ import com.neophob.sematrix.glue.PresentSettings;
 import com.neophob.sematrix.layout.BoxLayout;
 import com.neophob.sematrix.layout.HorizontalLayout;
 import com.neophob.sematrix.layout.Layout;
+import com.neophob.sematrix.output.OutputDeviceEnum;
 
 /**
  * load and save properties files
@@ -52,18 +53,19 @@ public final class PropertiesHelper {
 	
 	private static final String ERROR_NO_DEVICES_CONFIGURATED = "No devices configured, illegal configuration!";
 	private static final String ERROR_MULTIPLE_DEVICES_CONFIGURATED = "Multiple devices configured, illegal configuration!";
+	private static final String ERROR_UNKNOWN_DEVICES_CONFIGURATED = "Unknown devices configured, illegal configuration!";
 	
 	private Properties config=null;
+	
+	private OutputDeviceEnum outputDeviceEnum = null;
 	
 	private List<Integer> i2cAddr=null;
 	private List<DeviceConfig> lpdDevice=null;
 	private List<ColorFormat> colorFormat=null;
-
 	
 	private int devicesInRow1 = 0;
 	private int devicesInRow2 = 0;
 	
-
 	/**
 	 * 
 	 */
@@ -90,6 +92,15 @@ public final class PropertiesHelper {
 		if (devicesInRow1==0 && devicesInRow2==0) {
 			log.log(Level.SEVERE, ERROR_NO_DEVICES_CONFIGURATED);
 			throw new IllegalArgumentException(ERROR_NO_DEVICES_CONFIGURATED);
+		}
+		
+		if (rainbowduinoDevices > 0) {
+			this.outputDeviceEnum = OutputDeviceEnum.RAINBOWDUINO;
+		} else if (lpdDevices > 0) {
+			this.outputDeviceEnum = OutputDeviceEnum.LPD6803;
+		// TODO: Artnet device detection / configuration values
+		} else {
+			throw new IllegalArgumentException(ERROR_UNKNOWN_DEVICES_CONFIGURATED);
 		}
 		
 		//check that at least one device is configured,,
@@ -337,7 +348,10 @@ public final class PropertiesHelper {
 		return colorFormat;
 	}
 	
-	
-	
-
+	/**
+	 * @return the configured output device
+	 */
+	public OutputDeviceEnum getOutputDevice() {
+		return this.outputDeviceEnum;
+	}
 }


### PR DESCRIPTION
Hi,

I've changed the main PixelController class to be able to construct all known output devices depending on the current configuration properties so that I don't have to comment out the LPD6803 and uncomment the Rainbowduino code all the time. The PropertyHelper class now provided an OutputDeviceEnum instance initialized by the current configuration. To be able to provide Arduino related logging to both LPD6803 and Rainbowduino devices I've extracted the common variables and methods to a new ArduinoOutput class which extends the existing Output class.

I hope you find this changeset useful :)

Greetings,
Markus
