### PR TITLE
Anpassungen für Adalight-Output

### DIFF
--- a/src/main/java/com/neophob/sematrix/output/AdaVision.java
+++ b/src/main/java/com/neophob/sematrix/output/AdaVision.java
@@ -29,7 +29,7 @@ import com.neophob.sematrix.properties.PropertiesHelper;
 
 /**
  * Output device for adavision
- * 
+ *
  * @author michu
  *
  */
@@ -38,18 +38,18 @@ public class AdaVision extends OnePanelResolutionAwareOutput {
 	/** The log. */
 	private static final Logger LOG = Logger.getLogger(AdaVision.class.getName());
 
-	private static final int BPS = 115200;
+	private static final int BPS = 500000; //  hardcoded BPS, works with arduino uno R2 (ATMEL 8U2 for USB-Serial); adopt BPS also in "ledstream.pde"
 	private static final int HEADERSIZE = 6;
 
 	private static final String VERSION = "0.2";
 
 	private int panelsize;
-	
+
 	private byte[] buffer;
 	private Serial port;
-	
+
 	/**
-	 * 
+	 *
 	 * @param ph
 	 * @param controller
 	 */
@@ -69,7 +69,7 @@ public class AdaVision extends OnePanelResolutionAwareOutput {
 
 		this.panelsize = this.xResolution*this.yResolution;
  		port = new Serial(Collector.getInstance().getPapplet(), serialPort, BPS);
-				
+
 		// A special header / magic word is expected by the corresponding LED
 		// streaming code running on the Arduino.  This only needs to be initialized
 		// once (not in draw() loop) because the number of LEDs remains constant:
@@ -80,19 +80,19 @@ public class AdaVision extends OnePanelResolutionAwareOutput {
 		buffer[3] = (byte)((panelsize - 1) >> 8);      // LED count high byte
 		buffer[4] = (byte)((panelsize - 1) & 0xff);    // LED count low byte
 		buffer[5] = (byte)(buffer[3] ^ buffer[4] ^ 0x55); // Checksum
-		
+
 		initialized = true;
 	}
 
 	@Override
 	public void update() {
-		if (initialized) {							
-			writeSerialData(OutputHelper.convertBufferTo24bit(getTransformedBuffer(), colorFormat));			
-		}		
+		if (initialized) {
+			writeSerialData(OutputHelper.convertBufferTo24bit(getTransformedBuffer(), colorFormat));
+		}
 	}
 
 	/**
-	 * 
+	 *
 	 * @param buffer
 	 */
 	private synchronized void writeSerialData(byte[] rawBuffer) {
@@ -105,17 +105,17 @@ public class AdaVision extends OnePanelResolutionAwareOutput {
 			//and i discovered strange "hangs"...
 		} catch (Exception e) {
 			LOG.log(Level.INFO, "Error sending serial data!", e);
-		}		
+		}
 	}
-	
-	
+
+
 	@Override
 	public void close() {
 		if (initialized) {
 		    // Fill buffer (after header) with 0's, and issue to Arduino...
 		    Arrays.fill(buffer, HEADERSIZE, buffer.length, (byte)0);
 		    port.write(buffer);
-		    
+
 			port.dispose();
 		}
 	}

--- a/src/main/java/com/neophob/sematrix/output/OutputHelper.java
+++ b/src/main/java/com/neophob/sematrix/output/OutputHelper.java
@@ -39,7 +39,7 @@ public class OutputHelper {
 	private OutputHelper() {
 		//no instance allowed
 	}
-	
+
 	/**
 	 * this function feed the framebufferdata (32 pixels a 2bytes (aka 16bit)
 	 * to the send array. each second scanline gets inverteds
@@ -49,7 +49,7 @@ public class OutputHelper {
 	 */
 	public static int[] flipSecondScanline(int buffer[], int xResolution, int yResolution) {
 		int bufferTwo[] = buffer.clone();
-		
+
 		for (int y=0; y<yResolution; y++) {
 			if (y%2==1) {
 				int ofs = y*xResolution;
@@ -57,13 +57,13 @@ public class OutputHelper {
 					bufferTwo[ofs+x] = buffer[xResolution+ofs-x-1];
 				}
 			}
-		}		
+		}
 		return bufferTwo;
 	}
-	
+
 	/**
 	 * do manual mapping, this is used to support a more exotic device configuration
-	 * 
+	 *
 	 * @param buffer
 	 * @param xResolution
 	 * @param yResolution
@@ -77,16 +77,16 @@ public class OutputHelper {
 			if (i+1>lenght) {
 				LOG.log(Level.SEVERE, "Your manual mapping is wrong,the first index is 0! Invalid entry index: {0}", i);
 			} else {
-				bufferTwo[ofs++] = src[i]; 				
+				bufferTwo[ofs++] = src[i];
 			}
 		}
 		return bufferTwo;
 	}
-	
-	
-	
+
+
+
 	/**
-	 * 
+	 *
 	 * @param frameBuf
 	 * @return
 	 */
@@ -99,13 +99,13 @@ public class OutputHelper {
 			buffer[ofs++] = (byte) ((frameBuf[i]>>8)  & 0xff);
 			buffer[ofs  ] = (byte) ( frameBuf[i]      & 0xff);
 		}
-		
+
 		return buffer;
 	}
-	
-	
-	
-	
+
+
+
+
 	/**
 	 * Convert buffer to15bit.
 	 *
@@ -121,7 +121,7 @@ public class OutputHelper {
 		int tmp;
 		int ofs=0;
 
-		//step#1: split up r/g/b 
+		//step#1: split up r/g/b
 		for (int n=0; n<data.length; n++) {
 			//one int contains the rgb color
 			tmp = data[ofs];
@@ -130,14 +130,14 @@ public class OutputHelper {
 			case RGB:
 				r[ofs] = (int) ((tmp>>16) & 255);
 				g[ofs] = (int) ((tmp>>8)  & 255);
-				b[ofs] = (int) ( tmp      & 255);		
-				
+				b[ofs] = (int) ( tmp      & 255);
+
 				break;
 			case RBG:
 				r[ofs] = (int) ((tmp>>16) & 255);
 				b[ofs] = (int) ((tmp>>8)  & 255);
-				g[ofs] = (int) ( tmp      & 255);		
-				
+				g[ofs] = (int) ( tmp      & 255);
+
 				break;
 			}
 			ofs++;
@@ -157,7 +157,7 @@ public class OutputHelper {
 	private static byte[] convertTo15Bit(int[] r, int[] g, int[] b) {
 		int dst=0;
 		byte[] converted = new byte[128];
-		//convert to 24bpp to 15(16)bpp 
+		//convert to 24bpp to 15(16)bpp
 		//output format: RRRRRGGG GGGBBBBB (64x)
 		for (int i=0; i<64;i++) {
 			byte b1 = (byte)(r[i]>>3);
@@ -167,12 +167,12 @@ public class OutputHelper {
 			converted[dst++] = (byte)((b1<<2) | (b2>>3));
 			converted[dst++] = (byte)(((b2&7)<<5) | b3);
 		}
-		
+
 		return converted;
 	}
-	
-	
-	
+
+
+
 	/**
 	 * Convert internal buffer to 24bit byte buffer, using colorformat.
 	 *
@@ -183,14 +183,14 @@ public class OutputHelper {
 	 */
 	public static byte[] convertBufferTo24bit(int[] data, ColorFormat colorFormat) throws IllegalArgumentException {
 	    int targetBuffersize = data.length;
-		
+
 		int[] r = new int[targetBuffersize];
 		int[] g = new int[targetBuffersize];
 		int[] b = new int[targetBuffersize];
 		int tmp;
 		int ofs=0;
 
-		//step#1: split up r/g/b 
+		//step#1: split up r/g/b
 		for (int n=0; n<targetBuffersize; n++) {
 			//one int contains the rgb color
 			tmp = data[ofs];
@@ -199,14 +199,38 @@ public class OutputHelper {
 			case RGB:
 				r[ofs] = (int) ((tmp>>16) & 255);
 				g[ofs] = (int) ((tmp>>8)  & 255);
-				b[ofs] = (int) ( tmp      & 255);		
-				
+				b[ofs] = (int) ( tmp      & 255);
+
 				break;
 			case RBG:
 				r[ofs] = (int) ((tmp>>16) & 255);
 				b[ofs] = (int) ((tmp>>8)  & 255);
-				g[ofs] = (int) ( tmp      & 255);		
-				
+				g[ofs] = (int) ( tmp      & 255);
+
+				break;
+			case BRG:
+				b[ofs] = (int) ((tmp>>16) & 255);
+				r[ofs] = (int) ((tmp>>8)  & 255);
+				g[ofs] = (int) ( tmp      & 255);
+
+				break;
+			case BGR:
+				b[ofs] = (int) ((tmp>>16) & 255);
+				g[ofs] = (int) ((tmp>>8)  & 255);
+				r[ofs] = (int) ( tmp      & 255);
+
+				break;
+			case GBR:
+				g[ofs] = (int) ((tmp>>16) & 255);
+				b[ofs] = (int) ((tmp>>8)  & 255);
+				r[ofs] = (int) ( tmp      & 255);
+
+				break;
+			case GRB:
+				g[ofs] = (int) ((tmp>>16) & 255);
+				r[ofs] = (int) ((tmp>>8)  & 255);
+				b[ofs] = (int) ( tmp      & 255);
+
 				break;
 			}
 			ofs++;
@@ -219,10 +243,10 @@ public class OutputHelper {
 			buffer[ofs++] = (byte)g[i];
 			buffer[ofs++] = (byte)b[i];
 		}
-		
+
 		return buffer;
 	}
 
 
-	
+
 }

--- a/src/main/java/com/neophob/sematrix/properties/ColorFormat.java
+++ b/src/main/java/com/neophob/sematrix/properties/ColorFormat.java
@@ -23,12 +23,27 @@ package com.neophob.sematrix.properties;
  * color format of a hardware device.
  *
  * @author michu
- */
+*
+* @noxx6: added all possible RGB-LED color orders as valid input: 06.12.11
+*/
+
 public enum ColorFormat {
-	
+
 	/** The RGB. */
 	RGB,
-	
+
 	/** The RBG. */
-	RBG
+	RBG,
+
+	/** The BRG. */
+	BRG,
+
+	/** The BGR. */
+	BGR,
+
+	/** The GBR. */
+	GBR,
+
+	/** The GRB. */
+	GRB
 }

--- a/src/main/java/com/neophob/sematrix/properties/ConfigConstant.java
+++ b/src/main/java/com/neophob/sematrix/properties/ConfigConstant.java
@@ -27,22 +27,22 @@ public final class ConfigConstant {
 	private ConfigConstant() {
 		//Utility Class
 	}
-	
+
 	/** The Constant DELIM. */
 	public static final String DELIM = ",";
-	
+
 	/** The Constant RAINBOWDUINO_ROW1. */
 	public static final String RAINBOWDUINO_ROW1 = "layout.row1.i2c.addr";
-	
+
 	/** The Constant RAINBOWDUINO_ROW2. */
 	public static final String RAINBOWDUINO_ROW2 = "layout.row2.i2c.addr";
-	
+
 	/** The Constant CFG_PANEL_COLOR_ORDER. */
 	public static final String CFG_PANEL_COLOR_ORDER = "panel.color.order";
 
 	/** The Constant NULLOUTPUT_ROW1. */
 	public static final String NULLOUTPUT_ROW1 = "nulloutput.devices.row1";
-	
+
 	/** The Constant NULLOUTPUT_ROW2. */
 	public static final String NULLOUTPUT_ROW2 = "nulloutput.devices.row2";
 
@@ -52,20 +52,20 @@ public final class ConfigConstant {
 	/** The Constant ARTNET_IP. */
 	public static final String ARTNET_IP = "artnet.ip";
 
-	public static final String ARTNET_PIXELS_PER_UNIVERSE = "artnet.pixels.per.universe";	
-	public static final String ARTNET_FIRST_UNIVERSE_ID = "artnet.first.universe.id";	
-	
+	public static final String ARTNET_PIXELS_PER_UNIVERSE = "artnet.pixels.per.universe";
+	public static final String ARTNET_FIRST_UNIVERSE_ID = "artnet.first.universe.id";
+
 	/** The Constant OUTPUT_DEVICE_RESOLUTION_X. */
 	public static final String OUTPUT_DEVICE_RESOLUTION_X = "output.resolution.x";
-	
+
 	/** The Constant OUTPUT_DEVICE_RESOLUTION_Y. */
 	public static final String OUTPUT_DEVICE_RESOLUTION_Y = "output.resolution.y";
-	
+
     /** The Constant OUTPUT_DEVICE_SNAKE_CABELING */
     public static final String OUTPUT_DEVICE_SNAKE_CABELING = "output.snake.cabling";
-    
-    /** The Constant MINIDMX_BAUDRATE */
-    public static final String OUTPUT_DEVICE_LAYOUT = "minidmx.layout";
+
+    /** The Constant OUTPUT_DEVICE_LAYOUT */
+    public static final String OUTPUT_DEVICE_LAYOUT = "output.layout";  //renamed to work with adavision
 
 	/**	The Constant MINIDMX_BAUDRATE */
 	public static final String MINIDMX_BAUDRATE = "minidmx.baudrate";
@@ -76,45 +76,45 @@ public final class ConfigConstant {
 
 	/** The Constant STARTUP_IN_RANDOM_MODE. */
 	public static final String SOUND_AWARE_GENERATORS = "update.generators.by.sound";
-	
+
 	/** The Constant CFG_PIXEL_SIZE. */
 	public static final String CFG_PIXEL_SIZE = "led.pixel.size";
-	
+
 	/** The Constant PIXELINVADERS_ROW1. */
 	public static final String PIXELINVADERS_ROW1 = "pixelinvaders.layout.row1";
-	
+
 	/** The Constant PIXELINVADERS_ROW2. */
 	public static final String PIXELINVADERS_ROW2 = "pixelinvaders.layout.row2";
-	
+
 	/** The Constant NET_LISTENING_PORT. */
 	public static final String NET_LISTENING_PORT = "3448";
-	
+
 	/** The Constant NET_SEND_PORT. */
 	public static final String NET_SEND_PORT = "3449";
-	
+
 	/** The Constant NET_LISTENING_ADDR. */
 	public static final String NET_LISTENING_ADDR = "127.0.0.1";
-	
+
 	/** The Constant ADDITIONAL_VISUAL_SCREENS. */
 	public static final String ADDITIONAL_VISUAL_SCREENS = "additional.visual.screens";
-	
+
 	public static final String OUTPUT_MAPPING = "output.mapping";
-	
+
 	public static final String SHOW_DEBUG_WINDOW = "show.debug.window";
-	
+
 	public static final String DEBUG_WINDOW_MAX_X_SIZE = "maximal.debug.window.xsize";
-	
+
 	public static final String CAPTURE_OFFSET = "screen.capture.offset";
-	
+
 	public static final String CAPTURE_WINDOW_SIZE_X = "screen.capture.window.size.x";
 	public static final String CAPTURE_WINDOW_SIZE_Y = "screen.capture.window.size.y";
-	
+
 	public static final String FPS = "fps";
-	
+
 	public static final String COLORSCROLL_RGBCOLOR = "colorscroll.rgbcolor";
-	
+
 	public static final String COLORFADE_RGBCOLOR = "colorfade.rgbcolor";
-        
+
     public static final String PLASMA_RGBCOLOR = "plasma.rgbcolor";
-   
+
 }


### PR DESCRIPTION
Hi! 
Wie in der Email besprochen! Bilder zu meiner Matrix folgen! 

Anpassungen der Baudrate für Adalight-Output. Neue Auswahlmöglichkeit für Reihenfolge der LED-Beschaltung bei 24bit Farben (WS2801-Pixel) (alle Kombinationen jetzt möglich); Bugfix für die Abfrage der Orientierungsauswahl. 

Gruß Noxx
