### PR TITLE
Missing parameter on udp config example makes application to not show correctly the main window

### DIFF
--- a/data/config.examples/UDP-16x8.cfg
+++ b/data/config.examples/UDP-16x8.cfg
@@ -43,7 +43,9 @@ plasma.rgbcolor=0x3ff, 0xff00, 0x0000ff, 0xff0000
 #=========================
 net.listening.port=3448
 net.listening.addr=127.0.0.1
-net.send.port=3449
+net.send.port=
+
+osc.listening.port=9876
 
 #=========================
 #frames per second


### PR DESCRIPTION
Added the parameter osc.listening.port to the udp config example.
Without that parameter the java desktop gui doesn't initialize the main
window, showing a white panel.
