### PR TITLE
Don't capitalize TPM2 serial port name in Linux/OSX.

### DIFF
--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/Tpm2.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/Tpm2.java
@@ -63,7 +63,7 @@ public class Tpm2 extends OnePanelResolutionAwareOutput {
 
         // HINT: on windows you need to (for example) use COM1, com1 will not
         // work! (case sensitive)
-        String serialPortName = serialPort.getSerialPortName(ph.getTpm2Device().toUpperCase());
+        String serialPortName = serialPort.getSerialPortName(ph.getTpm2Device());
         this.initialized = false;
         this.supportConnectionState = true;
         try {

--- a/pixelcontroller-distribution/src/main/resources/data/config.properties
+++ b/pixelcontroller-distribution/src/main/resources/data/config.properties
@@ -287,7 +287,7 @@ nulloutput.devices.row2=0
 #=========================
 #Where is the TPM2 device connected?
 #  on Linux/OSX use names like "/dev/ttyUSB1"
-#  on Windows use names like "COM1"
+#  on Windows use names like "COM1" (Must be capitalized)
 #tpm2.device=/whatever/youwant
 #tpm2.baudrate=115200
 


### PR DESCRIPTION
The TPM2 serial port name is always capitalized. This only works in Windows and should be changed.
