### PR TITLE
tpm2serial: Add serialWaitRead() to block on byte reads.

### DIFF
--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/tpm2/Tpm2NetProtocol.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/tpm2/Tpm2NetProtocol.java
@@ -50,7 +50,7 @@ public final class Tpm2NetProtocol {
     private static final int TPM2_NET_HEADER_SIZE = 6;
     private static final byte START_BYTE = (byte) 0x9C;
     private static final byte DATA_FRAME = (byte) 0xDA;
-    private static final byte CMD_FRAME = (byte) 0xc0;
+    private static final byte CMD_FRAME = (byte) 0xC0;
     private static final byte BLOCK_END = (byte) 0x36;
 
     private Tpm2NetProtocol() {
@@ -94,8 +94,8 @@ public final class Tpm2NetProtocol {
         int frameSize = data.length;
         byte[] outputBuffer = new byte[frameSize + TPM2_NET_HEADER_SIZE + 1];
 
-        outputBuffer[0] = ((byte) (START_BYTE & 0xff));
-        outputBuffer[1] = ((byte) (CMD_FRAME & 0xff));
+        outputBuffer[0] = ((byte) (START_BYTE & 0xFF));
+        outputBuffer[1] = ((byte) (CMD_FRAME & 0xFF));
         outputBuffer[2] = ((byte) (frameSize >> 8 & 0xFF));
         outputBuffer[3] = ((byte) (frameSize & 0xFF));
         outputBuffer[4] = ((byte) 0);


### PR DESCRIPTION
I've got this running reliably on an Arduino Uno R2 with 50 RGB WS2811 LEDs on two separate computers. A major problem was the serial latency issue. I avoided it by writing a `serialWaitRead()` function which checks the return of the [Serial.read](http://arduino.cc/en/Serial/Read) call and loops until something other than -1 is returned.

``` arduino
int serialWaitRead() {
    int inByte = Serial.read();

    // Loop until a byte is read.
    while (inByte == -1) {
        inByte = Serial.read();
    }
    return inByte;
}
```

I added the `showError()` function to set all LEDs red. It is called when the Arduino is receiving invalid data and DEBUG is defined. If the data is all bad and `readCommand()` constantly returns a negative, then the LEDs just stay red. If only some of the data is bad, then the LEDs flicker red. (IDK why, but random packets have large incorrect frame size header values?) Summary: Comment DEBUG and you won't notice the dropped frames.

FYI _jpnevulator_ has worked well for me on Linux to watch the Arduino's debug responses:

```
jpnevulator --ascii --timing-print --tty /dev/ttyACM0 --read
```

I renamed some of the variables to for clarity (I hope that's alright!):
- packetBuffer -> frameData
- psize -> frameSize
- recvNr-> byteCount

Lastly, there is some formatting and additional documentation.
