### PR TITLE
tpm2serial: load the RGB data in RGB order, not BGR order.

### DIFF
--- a/pixelcontroller-distribution/src/main/resources/integration/ArduinoFw/tpm2serial/tpm2serial/tpm2serial.ino
+++ b/pixelcontroller-distribution/src/main/resources/integration/ArduinoFw/tpm2serial/tpm2serial/tpm2serial.ino
@@ -136,7 +136,8 @@ void updatePixels() {
   uint16_t ledOffset = PIXELS_PER_PACKET * currentPacket;
 
   for (uint16_t i=0; i<nrOfPixels; i++) {
-    leds[i+ledOffset] = CRGB(frameData[ofs++], frameData[ofs++], frameData[ofs++]);
+    leds[i+ledOffset] = CRGB(frameData[ofs], frameData[ofs+1], frameData[ofs+2]);
+    ofs = ofs + 3;
   }
 
   //update only if all data packets received


### PR DESCRIPTION
Probably due to the differences in compilers/host systems/something, the code:

``` arduino
leds[i+ledOffset] = CRGB(frameData[ofs++], frameData[ofs++], frameData[ofs++]);
```

can result in the frameData being retrieved in BGR order instead of RGB. It is not explict as to which `ofs++` runs first. This change makes the value retreival order explict. Maybe it works on teensy devices? It doesn't work as designed on the Arduino Uno.

I set `panel.color.order=BGR` during testing to make it work, but that's no actual solution.

_This is a separate pull request, because I wasn't sure it was the problem until after the last pull request was submitted and it may require further discussions._
