### PR TITLE
Add basic OpenPixelControl support and system-wide output brightness control

### DIFF
--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/listener/MessageProcessor.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/listener/MessageProcessor.java
@@ -572,6 +572,22 @@ public enum MessageProcessor {
                     }
                     break;
 
+                case CHANGE_OUTPUT_GAIN:
+                    try {
+                        int a = parseValue(msg[1]);
+                        if (a < 0 || a > 100) {
+                            LOG.log(Level.WARNING, IGNORE_COMMAND + ", invalid gain value: "
+                                    + a);
+                            break;
+                        } else {
+                            float f = a / 100f;
+                            col.setOutputGain(f);
+                        }
+                    } catch (Exception e) {
+                        LOG.log(Level.WARNING, IGNORE_COMMAND, e);
+                    }
+                    break;
+
                 case GENERATOR_SPEED:
                     try {
                         int fpsAdjustment = (int) Float.parseFloat(msg[1]);

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OpenPixelControl.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OpenPixelControl.java
@@ -55,7 +55,7 @@ public class OpenPixelControl extends OnePanelResolutionAwareOutput {
 
         LOG.log(Level.INFO, "Connect to target " + targetHost + ":" + targetPort);
         if (this.tcpImpl.initializeEthernet(targetHost, targetPort)) {
-            this.initialized = true;
+            initialized = true;
             LOG.log(Level.INFO, "initialized: " + this.initialized);
         } else {
             LOG.log(Level.INFO,
@@ -77,10 +77,13 @@ public class OpenPixelControl extends OnePanelResolutionAwareOutput {
             writeData(buffer);
         }
         else {
-            if (connectionErrorCounter % 10 == 9) {
-                // try to reconnect
-                LOG.log(Level.INFO, "Reinitialize TCP Socket");
-                tcpImpl.initializeEthernet(targetHost, targetPort);
+            // try to reconnect
+            if (this.tcpImpl.initializeEthernet(targetHost, targetPort)) {
+                initialized = true;
+                LOG.log(Level.INFO, "Reinitialized TCP Socket");
+            } else {
+                LOG.log(Level.INFO,
+                "Failed to reinitialize OPC target, verify the destination settings");
             }
         }
     }

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OpenPixelControl.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OpenPixelControl.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2011-2014 Michael Vogt <michu@neophob.com>
+ *
+ * This file is part of PixelController.
+ *
+ * PixelController is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PixelController is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PixelController.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.neophob.sematrix.core.output;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.neophob.sematrix.core.output.transport.ethernet.IEthernetTcp;
+import com.neophob.sematrix.core.properties.Configuration;
+import com.neophob.sematrix.core.resize.PixelControllerResize;
+import com.neophob.sematrix.core.visual.MatrixData;
+
+import java.net.SocketException;
+
+/**
+ * Send frames out via TCP
+ *
+ * @author rj
+ *
+ */
+public class OpenPixelControl extends OnePanelResolutionAwareOutput {
+
+    private static final transient Logger LOG = Logger.getLogger(OpenPixelControl.class.getName());
+
+    private transient IEthernetTcp tcpImpl;
+    private String targetHost;
+    private int targetPort;
+    private int connectionErrorCounter;
+    protected boolean initialized;
+
+    public OpenPixelControl(MatrixData matrixData, PixelControllerResize resizeHelper, Configuration ph,
+            IEthernetTcp tcpImpl) {
+        super(matrixData, resizeHelper, OutputDeviceEnum.OPEN_PIXEL_CONTROL, ph, 8);
+
+        targetHost = ph.getOpcIp();
+        targetPort = ph.getOpcPort();
+        this.tcpImpl = tcpImpl;
+
+        LOG.log(Level.INFO, "Connect to target " + targetHost + ":" + targetPort);
+        if (this.tcpImpl.initializeEthernet(targetHost, targetPort)) {
+            this.initialized = true;
+            LOG.log(Level.INFO, "initialized: " + this.initialized);
+        } else {
+            LOG.log(Level.INFO,
+                    "Failed to initialize OPC target, verify the destination settings");
+        }
+    }
+
+    @Override
+    public void update() {
+        if (initialized) {
+            byte[] buffer = OutputHelper.convertBufferTo24bit(getTransformedBuffer(), colorFormat, 4);
+
+            //Add the OPC header
+            buffer[0] = (byte) 0 & 0xFF; // address
+            buffer[1] = (byte) 0 & 0xFF; // command 0x00 (draw pixels)
+            buffer[2] = (byte) (((buffer.length-4) >> 8) & 0xFF); //high byte data length
+            buffer[3] = (byte) ((buffer.length-4) & 0xFF); //low byte data length
+
+            writeData(buffer);
+        }
+        else {
+            if (connectionErrorCounter % 10 == 9) {
+                // try to reconnect
+                LOG.log(Level.INFO, "Reinitialize TCP Socket");
+                tcpImpl.initializeEthernet(targetHost, targetPort);
+            }
+        }
+    }
+
+    protected synchronized void writeData(byte[] cmdfull) {
+        try {
+            tcpImpl.sendData(cmdfull);
+            initialized = true;
+        } catch (SocketException se) {
+            LOG.log(Level.INFO, "Error sending network data!", se);
+            connectionErrorCounter++;
+            initialized = false;
+        } catch (Exception e) {
+            connectionErrorCounter++;
+            initialized = false;
+            LOG.log(Level.INFO, "Connection error!", e);
+        }
+    }
+
+    @Override
+    public boolean isSupportConnectionState() {
+        return true;
+    }
+
+    @Override
+    public boolean isConnected() {
+        return initialized;
+    }
+
+    @Override
+    public String getConnectionStatus() {
+        if (initialized) {
+            return "Target IP " + targetHost + ":" + targetPort;
+        }
+        return "Not connected!";
+    }
+
+    @Override
+    public void close() {
+        tcpImpl.closePort();
+    }
+
+    @Override
+    public long getErrorCounter() {
+        return connectionErrorCounter;
+    }
+
+}

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OutputDeviceEnum.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OutputDeviceEnum.java
@@ -54,6 +54,9 @@ public enum OutputDeviceEnum {
 
     RPI_2801(RaspberrySpi2801.class, true),
 
+    /** Open Pixel Control **/
+    OPEN_PIXEL_CONTROL(OpenPixelControl.class, true),
+
     /** The NULL Output. */
     NULL(NullDevice.class, true);
 

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OutputHelper.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/OutputHelper.java
@@ -220,6 +220,40 @@ public class OutputHelper {
     }
 
     /**
+     * Convert internal buffer to 24bit byte buffer, using colorformat,
+     * offset by N bytes from the start of the buffer
+     * 
+     * @param data
+     *            the data
+     * @param colorFormat
+     *            the color format
+     * @param offset
+     *            extra bytes to pad at the start of the buffer before data
+     * @return the byte[]
+     * @throws IllegalArgumentException
+     *             the illegal argument exception
+     */
+    public static byte[] convertBufferTo24bit(int[] data, ColorFormat colorFormat, int offset)
+            throws IllegalArgumentException {
+        int targetBuffersize = data.length;
+
+        int[] r = new int[targetBuffersize];
+        int[] g = new int[targetBuffersize];
+        int[] b = new int[targetBuffersize];
+
+        splitUpBuffers(targetBuffersize, data, colorFormat, r, g, b);
+
+        byte[] buffer = new byte[(targetBuffersize * 3) + offset];
+        for (int i = 0; i < targetBuffersize; i++) {
+            buffer[offset++] = (byte) r[i];
+            buffer[offset++] = (byte) g[i];
+            buffer[offset++] = (byte) b[i];
+        }
+
+        return buffer;
+    }
+
+    /**
      * convert the int buffer in byte buffers, respecting the color order
      * 
      * @param targetBuffersize

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/PixelControllerOutput.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/PixelControllerOutput.java
@@ -121,6 +121,11 @@ public class PixelControllerOutput implements PixelControllerElement {
                     output = new RaspberrySpi2801(matrixData, resizeHelper, applicationConfig,
                             OutputTransportFactory.getRaspberryPiSpiImpl());
                     break;
+                case OPEN_PIXEL_CONTROL:
+                    output = new OpenPixelControl(matrixData, resizeHelper, applicationConfig,
+                            OutputTransportFactory.getTcpImpl());
+                    break;
+
                 default:
                     throw new IllegalArgumentException(
                             "Unable to initialize unknown output device: " + outputDeviceEnum);

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/gamma/Gammatab.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/output/gamma/Gammatab.java
@@ -79,7 +79,7 @@ public final class Gammatab {
      * @param brightness
      * @return
      */
-    public static int[] applyBrightnessAndGammaTab(int[] buffer, GammaType type, float brightness) {
+    public static int[] applyBrightnessAndGammaTab(int[] buffer, GammaType type, float brightness, float outputGain) {
         int[] ret = new int[buffer.length];
         int ofs = 0;
         int r, g, b;
@@ -91,9 +91,9 @@ public final class Gammatab {
             b = (int) (tmp & 255);
 
             // apply brightness
-            r = (int) (r * brightness);
-            g = (int) (g * brightness);
-            b = (int) (b * brightness);
+            r = (int) (r * brightness * outputGain);
+            g = (int) (g * brightness * outputGain);
+            b = (int) (b * brightness * outputGain);
 
             // apply gamma
             switch (type) {

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/preset/PresetServiceImpl.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/preset/PresetServiceImpl.java
@@ -92,6 +92,20 @@ public class PresetServiceImpl implements PresetService {
      * @return
      */
     private List<String> removeObsoleteCommands(List<String> preset) {
+        /* Global output gain should not be affected by presets
+           Yes, this is a little hacky; we could use a blacklist of
+           settings that never get saved to or read from presets */
+        if (preset.contains("CHANGE_OUTPUT_GAIN")) {
+            int ofs = 0;
+            for (String s : preset) {
+                if (s.startsWith("CHANGE_OUTPUT_GAIN")) {
+                    LOG.log(Level.INFO, "Removing Output gain from preset");
+                    break;
+                }
+                ofs++;
+            }
+            preset.remove(ofs);
+        }
         if (!preset.contains("CHANGE_GENERATOR_B 1") && !preset.contains("CHANGE_GENERATOR_A 1")) {
             LOG.log(Level.INFO, "No Blinkengenerator found, remove loading blinken resource");
             int ofs = 0;

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/preset/PresetSettings.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/preset/PresetSettings.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 
 /**
- * simple class to store present set's.
+ * simple class to store preset set's.
  * 
  * @author michu
  */
@@ -35,34 +35,34 @@ public class PresetSettings implements Serializable {
 
     private static final transient char DELIM = ';';
 
-    /** The present. */
+    /** The preset. */
     private List<String> preset;
     private String name = "";
 
     /**
-     * Gets the present.
+     * Gets the preset.
      * 
-     * @return the present
+     * @return the preset
      */
     public List<String> getPreset() {
         return preset;
     }
 
     /**
-     * Sets the present.
+     * Sets the preset.
      * 
-     * @param present
-     *            the new present
+     * @param preset
+     *            the new preset
      */
     public void setPreset(List<String> preset) {
         this.preset = preset;
     }
 
     /**
-     * Sets the present.
+     * Sets the preset.
      * 
-     * @param present
-     *            the new present
+     * @param preset
+     *            the new preset
      */
     public void setPreset(String[] preset) {
         List<String> list = new ArrayList<String>();

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigConstant.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigConstant.java
@@ -94,8 +94,8 @@ public final class ConfigConstant {
     public static final String STARTUP_IN_RANDOM_PRESET_MODE = "startup.in.random.presetmode";
     public static final String STARTUP_LOAD_PRESET_NR = "startup.load.preset.nr";
 
-    /** Constant for STARTUP_GLOBAL_OUTPUT_GAIN */
-    public static final String STARTUP_GLOBAL_OUTPUT_GAIN = "startup.global.output.gain";
+    /** Constant for STARTUP_OUTPUT_GAIN */
+    public static final String STARTUP_OUTPUT_GAIN = "startup.output.gain";
 
     /** The Constant STARTUP_IN_RANDOM_MODE. */
     public static final String SOUND_AWARE_GENERATORS = "sound.analyze.enabled";

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigConstant.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigConstant.java
@@ -67,6 +67,10 @@ public final class ConfigConstant {
     public static final String UDP_IP = "udp.ip";
     public static final String UDP_PORT = "udp.port";
 
+    /** Constants for Open Pixel Control **/
+    public static final String OPC_IP = "opc.ip";
+    public static final String OPC_PORT = "opc.port";
+
     /** The Constant OUTPUT_DEVICE_RESOLUTION_X. */
     public static final String OUTPUT_DEVICE_RESOLUTION_X = "output.resolution.x";
 

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigConstant.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigConstant.java
@@ -94,6 +94,9 @@ public final class ConfigConstant {
     public static final String STARTUP_IN_RANDOM_PRESET_MODE = "startup.in.random.presetmode";
     public static final String STARTUP_LOAD_PRESET_NR = "startup.load.preset.nr";
 
+    /** Constant for STARTUP_GLOBAL_OUTPUT_GAIN */
+    public static final String STARTUP_GLOBAL_OUTPUT_GAIN = "startup.global.output.gain";
+
     /** The Constant STARTUP_IN_RANDOM_MODE. */
     public static final String SOUND_AWARE_GENERATORS = "sound.analyze.enabled";
 

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigDefault.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigDefault.java
@@ -54,4 +54,6 @@ public final class ConfigDefault {
 
     public static final int DEFAULT_PIXELINVADERS_PANEL_RESOULTION = 8;
     public static final int DEFAULT_EXPEDITINVADERS_PANEL_RESOULTION = 4;
+
+    public static final int DEFAULT_STARTUP_GLOBAL_OUTPUT_GAIN = 100;
 }

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigDefault.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigDefault.java
@@ -55,5 +55,5 @@ public final class ConfigDefault {
     public static final int DEFAULT_PIXELINVADERS_PANEL_RESOULTION = 8;
     public static final int DEFAULT_EXPEDITINVADERS_PANEL_RESOULTION = 4;
 
-    public static final int DEFAULT_STARTUP_GLOBAL_OUTPUT_GAIN = 100;
+    public static final int DEFAULT_STARTUP_OUTPUT_GAIN = 100;
 }

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigDefault.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ConfigDefault.java
@@ -50,6 +50,8 @@ public final class ConfigDefault {
 
     public static final int DEFAULT_UDP_PORT = 6803;
 
+    public static final int DEFAULT_OPC_PORT = 7890;
+
     public static final int DEFAULT_PIXELINVADERS_PANEL_RESOULTION = 8;
     public static final int DEFAULT_EXPEDITINVADERS_PANEL_RESOULTION = 4;
 }

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/Configuration.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/Configuration.java
@@ -133,6 +133,7 @@ public class Configuration implements Serializable {
         int tpm2NetDevices = parseTpm2NetDevices();
         int udpDevices = parseUdpDevices();
         int rpi2801Devices = parseRpi2801Devices();
+        int opcDevices = parseOPCDevices();
         // track how many output systems are enabled
         int enabledOutputs = 0;
 
@@ -205,6 +206,14 @@ public class Configuration implements Serializable {
             LOG.log(Level.INFO, "found RPI2801 device: " + totalDevices);
             this.outputDeviceEnum = OutputDeviceEnum.RPI_2801;
         }
+        if(opcDevices > 0) {
+            enabledOutputs++;
+            totalDevices = opcDevices;
+            LOG.log(Level.INFO, "found OPC device: " + totalDevices);
+            this.outputDeviceEnum = OutputDeviceEnum.OPEN_PIXEL_CONTROL;
+        }
+
+
         if (nullDevices > 0) {
             // enable null output only if configured AND no other output is
             // enabled.
@@ -676,6 +685,24 @@ public class Configuration implements Serializable {
         return parseInt(ConfigConstant.UDP_PORT, ConfigDefault.DEFAULT_UDP_PORT);
     }
 
+      /**
+     * get configured OPC ip.
+     * 
+     * @return the tcp ip
+     */
+    public String getOpcIp() {
+        return config.getProperty(ConfigConstant.OPC_IP);
+    }
+
+    /**
+     * get configured OPC port.
+     * 
+     * @return the tcp port
+     */
+    public int getOpcPort() {
+        return parseInt(ConfigConstant.OPC_PORT, ConfigDefault.DEFAULT_OPC_PORT);
+    }
+
     /**
      * get configured e131 ip.
      * 
@@ -887,6 +914,19 @@ public class Configuration implements Serializable {
 
     public int parseRpi2801Devices() {
         if (getRpiWs2801SpiSpeed() > 1000 && parseOutputXResolution() > 0
+                && parseOutputYResolution() > 0) {
+            this.devicesInRow1 = 1;
+            this.devicesInRow2 = 0;
+            this.deviceXResolution = parseOutputXResolution();
+            this.deviceYResolution = parseOutputYResolution();
+            return 1;
+        }
+
+        return 0;
+    }
+
+    public int parseOPCDevices() {
+        if (StringUtils.length(getOpcIp()) > 6 && parseOutputXResolution() > 0
                 && parseOutputYResolution() > 0) {
             this.devicesInRow1 = 1;
             this.devicesInRow2 = 0;

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/Configuration.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/Configuration.java
@@ -598,12 +598,12 @@ public class Configuration implements Serializable {
      * @return int gain value from cfg or default
      */
     private int parseStartupOutputGain() {
-        String tmp = config.getProperty(ConfigConstant.STARTUP_GLOBAL_OUTPUT_GAIN, ""
-                + ConfigDefault.DEFAULT_STARTUP_GLOBAL_OUTPUT_GAIN);
+        String tmp = config.getProperty(ConfigConstant.STARTUP_OUTPUT_GAIN, ""
+                + ConfigDefault.DEFAULT_STARTUP_OUTPUT_GAIN);
         try {
             int ti = Integer.parseInt(tmp);
             if (ti < 0 || ti > 100) {
-                LOG.log(Level.WARNING, ConfigConstant.STARTUP_GLOBAL_OUTPUT_GAIN + ", invalid startup gain value: "
+                LOG.log(Level.WARNING, ConfigConstant.STARTUP_OUTPUT_GAIN + ", invalid startup gain value: "
                     + ti);
             } else {
                 return ti;
@@ -611,7 +611,7 @@ public class Configuration implements Serializable {
         } catch (NumberFormatException e) {
             LOG.log(Level.WARNING, FAILED_TO_PARSE, e);
         }
-        return ConfigDefault.DEFAULT_STARTUP_GLOBAL_OUTPUT_GAIN;
+        return ConfigDefault.DEFAULT_STARTUP_OUTPUT_GAIN;
     }
 
     /**

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/Configuration.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/Configuration.java
@@ -109,6 +109,9 @@ public class Configuration implements Serializable {
     /** user selected gamma correction */
     private GammaType gammaType;
 
+    /** user selected startup output gain */
+    private int startupOutputGain = 0;
+
     private String pixelinvadersNetIp;
     private int pixelinvadersNetPort;
 
@@ -281,6 +284,8 @@ public class Configuration implements Serializable {
         }
 
         gammaType = parseGammaCorrection();
+
+        startupOutputGain = parseStartupOutputGain();
     }
 
     /**
@@ -585,6 +590,28 @@ public class Configuration implements Serializable {
             LOG.log(Level.WARNING, FAILED_TO_PARSE, ConfigConstant.CFG_PANEL_GAMMA_TAB);
         }
         return ret;
+    }
+
+    /**
+     * Parses the startup global output gain
+     *
+     * @return int gain value from cfg or default
+     */
+    private int parseStartupOutputGain() {
+        String tmp = config.getProperty(ConfigConstant.STARTUP_GLOBAL_OUTPUT_GAIN, ""
+                + ConfigDefault.DEFAULT_STARTUP_GLOBAL_OUTPUT_GAIN);
+        try {
+            int ti = Integer.parseInt(tmp);
+            if (ti < 0 || ti > 100) {
+                LOG.log(Level.WARNING, ConfigConstant.STARTUP_GLOBAL_OUTPUT_GAIN + ", invalid startup gain value: "
+                    + ti);
+            } else {
+                return ti;
+            }
+        } catch (NumberFormatException e) {
+            LOG.log(Level.WARNING, FAILED_TO_PARSE, e);
+        }
+        return ConfigDefault.DEFAULT_STARTUP_GLOBAL_OUTPUT_GAIN;
     }
 
     /**
@@ -1364,6 +1391,15 @@ public class Configuration implements Serializable {
      */
     public GammaType getGammaType() {
         return gammaType;
+    }
+
+    /**
+     * return user selected startup output gain
+     * 
+     * @return
+     */
+    public int getStartupOutputGain() {
+        return startupOutputGain;
     }
 
     /**

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ValidCommand.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ValidCommand.java
@@ -121,8 +121,8 @@ public enum ValidCommand {
 
     CHANGE_BRIGHTNESS(CommandGroup.GENERATOR, 1, "<INT> output brightness 0 .. 100"),
 
-    /** Global Output Gain */
-    CHANGE_OUTPUT_GAIN(CommandGroup.MISC, 1, "<INT> global output gain, 0-100"),
+    /** Output Gain */
+    CHANGE_OUTPUT_GAIN(CommandGroup.MISC, 1, "<INT> output gain, 0-100 (%)"),
 
     GENERATOR_SPEED(CommandGroup.GENERATOR, 1,
             "<INT> generator speed 0 .. 200 (default speed is 100)"),

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ValidCommand.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/properties/ValidCommand.java
@@ -121,6 +121,9 @@ public enum ValidCommand {
 
     CHANGE_BRIGHTNESS(CommandGroup.GENERATOR, 1, "<INT> output brightness 0 .. 100"),
 
+    /** Global Output Gain */
+    CHANGE_OUTPUT_GAIN(CommandGroup.MISC, 1, "<INT> global output gain, 0-100"),
+
     GENERATOR_SPEED(CommandGroup.GENERATOR, 1,
             "<INT> generator speed 0 .. 200 (default speed is 100)"),
 

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/visual/VisualState.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/visual/VisualState.java
@@ -118,8 +118,8 @@ public class VisualState extends Observable {
 
     private float brightness = 1.0f;
 
-    /** Global output gain */
-    private float outputGain = 0.0f;
+    /** Output gain */
+    private float outputGain = 1.0f;
 
     // the fps multiplier
     private float fpsSpeed = 1.0f;

--- a/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/visual/VisualState.java
+++ b/pixelcontroller-core/src/main/java/com/neophob/sematrix/core/visual/VisualState.java
@@ -118,6 +118,9 @@ public class VisualState extends Observable {
 
     private float brightness = 1.0f;
 
+    /** Global output gain */
+    private float outputGain = 0.0f;
+
     // the fps multiplier
     private float fpsSpeed = 1.0f;
 
@@ -616,6 +619,13 @@ public class VisualState extends Observable {
         return brightness;
     }
 
+    /**
+     * @return the output gain
+     */
+    public float getOutputGain() {
+        return outputGain;
+    }
+
     public float getFpsSpeed() {
         return fpsSpeed;
     }
@@ -632,6 +642,14 @@ public class VisualState extends Observable {
         this.brightness = brightness;
     }
 
+    /**
+     * @param outputGain
+     *            the output gain to set
+     */
+    public void setOutputGain(float outputGain) {
+        this.outputGain = outputGain;
+    }
+
     public boolean isPassThroughModeEnabledForCurrentVisual() {
         return getVisual(currentVisual).isPassThroughModeEnabledForCurrentVisual();
     }
@@ -643,6 +661,8 @@ public class VisualState extends Observable {
         ret.add(ValidCommand.CHANGE_BRIGHTNESS + " " + brightnessInt);
         int generatorSpeed = (int) (this.fpsSpeed * 100f);
         ret.add(ValidCommand.GENERATOR_SPEED + " " + generatorSpeed);
+        int outputGainInt =  (int) (this.outputGain * 100f);
+        ret.add(ValidCommand.CHANGE_OUTPUT_GAIN + " " + outputGainInt);
 
         // add element status
         ret.addAll(pixelControllerEffect.getCurrentState());

--- a/pixelcontroller-core/src/test/java/com/neophob/sematrix/core/output/gamma/GammaTest.java
+++ b/pixelcontroller-core/src/test/java/com/neophob/sematrix/core/output/gamma/GammaTest.java
@@ -37,21 +37,21 @@ public class GammaTest {
 	@Test
 	public void applyGammaTest() {
 		int[] buffer = new int[] {0,32,64,96,128,192,224};
-		int[] resultNone = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.NONE, 1f);
+		int[] resultNone = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.NONE, 1f, 1f);
 		assertTrue(Arrays.equals(buffer, resultNone));
 		
-		int[] resultg20 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_20, 1f);
+		int[] resultg20 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_20, 1f, 1f);
 		assertFalse(Arrays.equals(buffer, resultg20));
 		
-		int[] resultg22 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_22, 1f);
+		int[] resultg22 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_22, 1f, 1f);
 		assertFalse(Arrays.equals(buffer, resultg22));
 		assertFalse(Arrays.equals(resultg20, resultg22));
 		
-		int[] resultg25 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_25, 1f);
+		int[] resultg25 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_25, 1f, 1f);
 		assertFalse(Arrays.equals(buffer, resultg25));
 		assertFalse(Arrays.equals(resultg20, resultg25));
 		
-		int[] resultb5 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_25, 0.5f);
+		int[] resultb5 = Gammatab.applyBrightnessAndGammaTab(buffer, GammaType.GAMMA_25, 0.5f, 1f);
 		assertFalse(Arrays.equals(resultg25, resultb5));
 		assertFalse(Arrays.equals(buffer, resultb5));
 	}

--- a/pixelcontroller-distribution/src/main/resources/data/config.examples/openpixelcontrol.properties
+++ b/pixelcontroller-distribution/src/main/resources/data/config.examples/openpixelcontrol.properties
@@ -13,7 +13,7 @@ screen.capture.window.size.y=300
 #=========================
 #frames per second, examples: fps=25 (default), fps=0.1
 #=========================
-fps=50
+fps=25
 
 #=========================
 #settings for remote client (client/server)
@@ -72,8 +72,8 @@ sound.silence.threshold=0.0005f
 #=========================
 #GUI: define the maximal window size
 #=========================
-gui.window.maximal.width=1600
-gui.window.maximal.height=1200
+gui.window.maximal.width=800
+gui.window.maximal.height=600
 
 #=========================
 #GUI: the size of the software output matrix
@@ -128,9 +128,9 @@ panel.gamma.tab=NONE
 
 #=========================
 # Global Output Gain at startup
-# Defaults to 50%
+# Defaults to 100%
 #=========================
-#startup.global.output.gain=50
+#startup.global.output.gain=100
 
 #=========================
 # Settings for PixelInvaders panels, valid options:

--- a/pixelcontroller-distribution/src/main/resources/data/config.examples/openpixelcontrol.properties
+++ b/pixelcontroller-distribution/src/main/resources/data/config.examples/openpixelcontrol.properties
@@ -127,6 +127,12 @@ output.snake.cabling=false
 panel.gamma.tab=NONE
 
 #=========================
+# Global Output Gain at startup
+# Defaults to 50%
+#=========================
+#startup.global.output.gain=50
+
+#=========================
 # Settings for PixelInvaders panels, valid options:
 #=========================
 #   NO_ROTATE,

--- a/pixelcontroller-distribution/src/main/resources/data/config.examples/openpixelcontrol.properties
+++ b/pixelcontroller-distribution/src/main/resources/data/config.examples/openpixelcontrol.properties
@@ -2,19 +2,18 @@
 # Generator options
 #=========================
 font.filename=04B_03__.TTF
-font.size=82
+font.size=40
 
 #x/y offset for screen capturing generator
 #if you define screen.capture.window.size.x as 0, the screen capture generator will be disabled
 screen.capture.offset=100
-screen.capture.window.size.x=0
-#screen.capture.window.size.x=500
+screen.capture.window.size.x=500
 screen.capture.window.size.y=300
 
 #=========================
 #frames per second, examples: fps=25 (default), fps=0.1
 #=========================
-fps=25
+fps=50
 
 #=========================
 #settings for remote client (client/server)
@@ -37,7 +36,7 @@ startup.in.random.presetmode=false
 #if the random mode is enabled, create a random visual each n seconds
 #if this value is 0, then this feature is disabled
 #=========================
-randommode.lifetime.in.s=15
+randommode.lifetime.in.s=30
 
 #=========================
 #per default you get # of output windows + 1 visuals
@@ -73,13 +72,13 @@ sound.silence.threshold=0.0005f
 #=========================
 #GUI: define the maximal window size
 #=========================
-gui.window.maximal.width=620
-gui.window.maximal.height=600
+gui.window.maximal.width=1600
+gui.window.maximal.height=1200
 
 #=========================
 #GUI: the size of the software output matrix
 #=========================
-led.pixel.size=16
+led.pixel.size=8
 
 
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ###
@@ -91,13 +90,13 @@ led.pixel.size=16
 # the resolution of your led matrix
 # this setting is not needed for pixelinvaders panels
 #=========================
-output.resolution.x=8
+output.resolution.x=64
 output.resolution.y=8
 
 #=========================
 #flip each second scanline
 #=========================
-#output.snake.cabling=true
+output.snake.cabling=false
 
 #=========================
 # if your led matrix has a fancy ordering, enter the custom mapping here
@@ -125,7 +124,7 @@ output.resolution.y=8
 #  - GAMMA_30: apply gamma 3.0 correction
 #  - SPECIAL1: apply special gamma correction
 #=========================
-panel.gamma.tab=GAMMA_22
+panel.gamma.tab=NONE
 
 #=========================
 # Settings for PixelInvaders panels, valid options:
@@ -175,8 +174,8 @@ panel.gamma.tab=GAMMA_22
 #=========================
 #settings for null output
 #=========================
-nulloutput.devices.row1=2
-nulloutput.devices.row2=0
+#nulloutput.devices.row1=2
+#nulloutput.devices.row2=0
 
 #=========================
 #settings for rainbowduinoV2
@@ -281,6 +280,17 @@ nulloutput.devices.row2=0
 #udp.ip=192.168.111.25
 #udp.port=6803
 
+
+#=========================
+#settings for Open Pixel Control (OPC) "device"
+#do NOT FORGET to define the output resolution above!
+#=========================
+opc.ip=127.0.0.1
+opc.port=7890
+opc.layout.row1=NO_ROTATE,NO_ROTATE
+opc.layout.row1=NO_ROTATE,NO_ROTATE
+
+
 #=========================
 #settings for tpm2 device
 #do NOT FORGET to define the output resolution above!
@@ -297,14 +307,6 @@ nulloutput.devices.row2=0
 #=========================
 #rpiws2801.spi.speed=1000000
 
-#=========================
-#settings for Open Pixel Control (OPC) "device"
-#do NOT FORGET to define the output resolution above!
-#=========================
-#opc.ip=127.0.0.1
-#opc.port=7890
-#opc.layout.row1=NO_ROTATE,NO_ROTATE
-#opc.layout.row1=NO_ROTATE,NO_ROTATE
 
 #=========================
 #settings for miniDmx (like the SEDU board)

--- a/pixelcontroller-distribution/src/main/resources/data/config.properties
+++ b/pixelcontroller-distribution/src/main/resources/data/config.properties
@@ -128,10 +128,10 @@ output.resolution.y=8
 panel.gamma.tab=GAMMA_22
 
 #=========================
-# Global Output Gain at startup
-# Defaults to 50%
+# Output Gain at startup
+# Defaults to 100%
 #=========================
-#startup.global.output.gain=50
+#startup.output.gain=100
 
 
 #=========================

--- a/pixelcontroller-distribution/src/main/resources/data/config.properties
+++ b/pixelcontroller-distribution/src/main/resources/data/config.properties
@@ -128,6 +128,13 @@ output.resolution.y=8
 panel.gamma.tab=GAMMA_22
 
 #=========================
+# Global Output Gain at startup
+# Defaults to 50%
+#=========================
+#startup.global.output.gain=50
+
+
+#=========================
 # Settings for PixelInvaders panels, valid options:
 #=========================
 #   NO_ROTATE,


### PR DESCRIPTION
I added these features for a project. Perhaps they are useful for your project more generally.

1: Added OPC (OpenPixelControl http://openpixelcontrol.org/) support
- I re-used your tcpImpl classes and add the necessary headers
- The fadecandy device I'm using supports gamma control so I will at some point add gamma adjustment offload

2: Add output gain control
- I needed to limit the output brightness of all outputs, in a way that is not affected by presets but still real-time controllable eg. by OSC
- Slightly hacky solution that defines a new parameter that applies to all outputs but is removed from presets
- Config file contains a value that is set at startup
- Defaults to 100% so all tests pass
- No GUI control